### PR TITLE
Add README with environment variables and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Berlin Home Finder
+
+This repository contains a script that scans Berlin housing websites and sends you Telegram notifications when new apartment listings match predefined criteria.
+
+## Environment Variables
+
+Set the following variables before running the script:
+
+- `TELEGRAM_BOT_TOKEN` – token of your Telegram bot.
+- `TELEGRAM_USER_ID` – your Telegram chat ID to receive notifications.
+- `STATE_FILE` – optional path for storing seen listing IDs (defaults to `./notified.pkl`).
+
+## Running
+
+Install dependencies and run the scanner:
+
+```bash
+pip install -r requirements.txt
+playwright install --with-deps chromium
+python scan.py
+```
+
+Alternatively, use the provided Dockerfile:
+
+```bash
+docker build -t berlin-home-finder .
+docker run -e TELEGRAM_BOT_TOKEN=... -e TELEGRAM_USER_ID=... berlin-home-finder
+```
+


### PR DESCRIPTION
## Summary
- document purpose and environment variables in README
- show quickstart commands with Docker option

## Testing
- `python -m py_compile scan.py`

------
https://chatgpt.com/codex/tasks/task_e_6840ac14bccc83328004392976dfc61b