### PR TITLE
Fix dynamic scanner scheduling

### DIFF
--- a/scan.py
+++ b/scan.py
@@ -323,7 +323,7 @@ async def job() -> None:
         if datetime.utcnow().minute % 3 == 0:
             scanners.append(scan_inberlinwohnen)
 
-        results = await asyncio.gather(*(scan() for scan in SCANNERS))
+        results = await asyncio.gather(*(scan() for scan in scanners))
         flat = [item for sub in results for item in sub]
         await send_notifications(flat)
         log.info(


### PR DESCRIPTION
## Summary
- use the local `scanners` list when launching scanner tasks
- keep `scan_inberlinwohnen` conditional so it runs every third minute

## Testing
- `python3 -m py_compile scan.py`


------
https://chatgpt.com/codex/tasks/task_e_6840ac2f77dc83328ae2cbb6a409fa04