### PR TITLE
Fix utcnow deprecation in scan

### DIFF
--- a/scan.py
+++ b/scan.py
@@ -320,7 +320,7 @@ async def job() -> None:
         ]
         # call inberlinwohnen only when the current minute is a multiple of 3
         # in other words, scan inberlinwohnen every 3 minutes instead of every 1 minute
-        if datetime.utcnow().minute % 3 == 0:
+        if datetime.now(timezone.utc).minute % 3 == 0:
             scanners.append(scan_inberlinwohnen)
 
         results = await asyncio.gather(*(scan() for scan in scanners))


### PR DESCRIPTION
## Summary
- replace deprecated `datetime.utcnow()` with `datetime.now(timezone.utc)`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840b4422ad88332956c546990f8c403