### PR TITLE
Include provider names in Telegram alerts

### DIFF
--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -60,6 +60,7 @@ def test_scan_gewobag(monkeypatch):
             "rent": None,
             "title": "Top Wohnung",
             "address": "Berlin",
+            "provider": "Gewobag",
         }
     ]
 
@@ -129,6 +130,7 @@ def test_scan_wbm(monkeypatch):
             "rent": None,
             "title": None,
             "address": None,
+            "provider": "WBM",
         }
     ]
 
@@ -160,6 +162,7 @@ def test_scan_inberlinwohnen(monkeypatch):
             "rent": "1200",
             "title": "Feine Wohnung",
             "address": None,
+            "provider": "inBerlinWohnen",
         }
     ]
 


### PR DESCRIPTION
## Summary
- add a `provider` field to each listing
- include a brief description and provider name in Telegram messages
- adjust scanners and tests for the new field

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849f6e4a13083329a92e90f31d1928b