### PR TITLE
Filter WBM from inberlinwohnen

### DIFF
--- a/scan.py
+++ b/scan.py
@@ -262,6 +262,8 @@ async def scan_inberlinwohnen() -> List[Listing]:
             link = li.find("a", title=lambda t: t and "detailierte" in t)["href"]
             if not link.startswith("http"):
                 link = "https://inberlinwohnen.de" + link
+            if "wbm.de" in link:
+                continue  # skip WBM entries to avoid duplicates
             listings.append(
                 Listing(
                     id=f"inberlinwohnen_{lid}",

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -167,6 +167,27 @@ def test_scan_inberlinwohnen(monkeypatch):
     ]
 
 
+def test_scan_inberlinwohnen_skip_wbm(monkeypatch):
+    html = """
+    <ul id='_tb_relevant_results'>
+        <li id='b2' class='tb-merkflat'>
+            <a title='detailierte Ansicht' href='https://www.wbm.de/foo'>Link</a>
+            <h3>WBM</h3>
+            <strong>3</strong>
+            <strong>70</strong>
+            <strong>ab 1200 €</strong>
+        </li>
+    </ul>
+    """
+
+    async def fake_fetch(url, *, params=None, timeout=12):
+        return html
+
+    monkeypatch.setattr(scan, "fetch", fake_fetch)
+    listings = asyncio.run(scan.scan_inberlinwohnen())
+    assert listings == []
+
+
 def test_scan_stubs():
     assert asyncio.run(scan.scan_gesobau()) == []
     assert asyncio.run(scan.scan_degewo()) == []


### PR DESCRIPTION
## Summary
- filter out WBM listings when scanning inberlinwohnen
- test that WBM entries are skipped

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852704a0c608332a1ced6f1517d435f