### PR TITLE
Handle Gewobag navigation failures

### DIFF
--- a/scan.py
+++ b/scan.py
@@ -175,7 +175,8 @@ async def scan_gewobag() -> List[Listing]:
                         "Gewobag navigation failed (%d/3): %s", attempt + 1, exc
                     )
                     if attempt == 2:
-                        raise
+                        log.error("Gewobag navigation failed after retries: %s", exc)
+                        return []
                     await asyncio.sleep(attempt + 1)
             try:
                 await page.wait_for_selector(

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -160,6 +160,7 @@ def test_scan_gewobag_retry_success(monkeypatch):
 
 def test_scan_gewobag_retry_fail(monkeypatch):
     attempts = {"count": 0}
+    error_calls = []
 
     class DummyPage:
         async def goto(self, url, **kwargs):
@@ -192,11 +193,17 @@ def test_scan_gewobag_retry_fail(monkeypatch):
     async def fake_sleep(_):
         pass
 
+    def fake_error(msg, *args, **kwargs):
+        error_calls.append(kwargs.get("exc_info"))
+
     monkeypatch.setattr(scan, "ensure_browser", fake_ensure_browser)
     monkeypatch.setattr(scan.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(scan.log, "error", fake_error)
+
     listings = asyncio.run(scan.scan_gewobag())
     assert attempts["count"] == 3
     assert listings == []
+    assert error_calls == [None]
 
 
 def test_scan_wbm(monkeypatch):


### PR DESCRIPTION
## Summary
- Gracefully abort Gewobag scan after repeated navigation errors
- Test retry failure path without emitting stack traces

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890bb5e1c648332920edbada0c255cb