### PR TITLE
Improve Telegram listing alerts

### DIFF
--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -292,3 +292,41 @@ def test_scan_stubs():
     assert asyncio.run(scan.scan_degewo()) == []
     assert asyncio.run(scan.scan_howoge()) == []
     assert asyncio.run(scan.scan_stadtundland()) == []
+
+
+def test_build_message_with_location_and_rent():
+    listing = {
+        "id": "demo_1",
+        "rooms": 3.0,
+        "sqm": 72.0,
+        "link": "https://example.com/listing",
+        "rent": "1450",
+        "title": "Helle Wohnung",
+        "address": "Prenzlauer Berg",
+        "provider": "DemoProvider",
+    }
+
+    message = scan.build_message(listing)
+
+    assert "Prenzlauer Berg" in message
+    assert "1450 €" in message
+    assert "<b>DemoProvider</b>" in message
+
+
+def test_build_message_without_location_or_rent():
+    listing = {
+        "id": "demo_2",
+        "rooms": 2.5,
+        "sqm": 65.0,
+        "link": "https://example.com/listing2",
+        "rent": None,
+        "title": "Schöne Wohnung",
+        "address": None,
+        "provider": "DemoProvider",
+    }
+
+    message = scan.build_message(listing)
+
+    assert "📍" not in message
+    assert "💶" not in message
+    assert "Listing</a>" in message


### PR DESCRIPTION
## Summary
- format Telegram notifications with HTML so alerts can include provider, address, rent and link details
- add helper utilities around message building and cover them with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d035f90f3c833281f0e9d2d77c0373