### PR TITLE
[codex] Persist successful Telegram notifications

### DIFF
--- a/scan.py
+++ b/scan.py
@@ -433,9 +433,11 @@ async def job() -> None:
         )
 
 
-# schedule cron task
-aiocron.crontab(CRON_SCHEDULE, func=lambda: asyncio.create_task(job()), start=True)
-log.info("Cron %s registered – entering loop", CRON_SCHEDULE)
+def main() -> None:
+    aiocron.crontab(CRON_SCHEDULE, func=lambda: asyncio.create_task(job()), start=True)
+    log.info("Cron %s registered – entering loop", CRON_SCHEDULE)
+    asyncio.get_event_loop().run_forever()
+
 
 if __name__ == "__main__":
-    asyncio.get_event_loop().run_forever()
+    main()

--- a/scan.py
+++ b/scan.py
@@ -382,17 +382,28 @@ async def send_notifications(listings: List[Listing]) -> None:
     fresh = [l for l in listings if l["id"] not in notified]
     if not fresh:
         return
+    sent = 0
     for l in fresh:          # ← sequential loop
         log.debug("Sending listing %s (%s)", l["id"], l["link"])
-        await bot.send_message(
-            chat_id=TG_CHAT,
-            text=build_message(l),
-            parse_mode=ParseMode.HTML,
-            disable_web_page_preview=True,
-        )
-    notified.update(l["id"] for l in fresh)
-    save_state(notified)
-    log.info("Sent %d Telegram messages", len(fresh))
+        try:
+            await bot.send_message(
+                chat_id=TG_CHAT,
+                text=build_message(l),
+                parse_mode=ParseMode.HTML,
+                disable_web_page_preview=True,
+            )
+        except Exception as exc:
+            log.error(
+                "Failed to send Telegram message for %s: %s",
+                l["id"],
+                exc,
+                exc_info=True,
+            )
+            continue
+        notified.add(l["id"])
+        save_state(notified)
+        sent += 1
+    log.info("Sent %d Telegram messages", sent)
 
 
 # ─────────────────────────  MAIN JOB  ────────────────────────────── #

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -338,3 +338,60 @@ def test_build_message_without_location_or_rent():
     assert "📍" not in message
     assert "💶" not in message
     assert "Listing</a>" in message
+
+
+def test_send_notifications_persists_successes_after_partial_failure(monkeypatch):
+    sent_links = []
+    saved_states = []
+
+    class FakeBot:
+        async def send_message(self, *, chat_id, text, parse_mode, disable_web_page_preview):
+            if "example.com/b" in text:
+                raise RuntimeError("telegram unavailable")
+            sent_links.append(text)
+
+    listings = [
+        {
+            "id": "a",
+            "rooms": 3.0,
+            "sqm": 70.0,
+            "link": "https://example.com/a",
+            "rent": None,
+            "title": "A",
+            "address": None,
+            "provider": "DemoProvider",
+        },
+        {
+            "id": "b",
+            "rooms": 3.0,
+            "sqm": 71.0,
+            "link": "https://example.com/b",
+            "rent": None,
+            "title": "B",
+            "address": None,
+            "provider": "DemoProvider",
+        },
+        {
+            "id": "c",
+            "rooms": 3.0,
+            "sqm": 72.0,
+            "link": "https://example.com/c",
+            "rent": None,
+            "title": "C",
+            "address": None,
+            "provider": "DemoProvider",
+        },
+    ]
+
+    def fake_save_state(state):
+        saved_states.append(set(state))
+
+    monkeypatch.setattr(scan, "bot", FakeBot())
+    monkeypatch.setattr(scan, "notified", set())
+    monkeypatch.setattr(scan, "save_state", fake_save_state)
+
+    asyncio.run(scan.send_notifications(listings))
+
+    assert len(sent_links) == 2
+    assert scan.notified == {"a", "c"}
+    assert saved_states == [{"a"}, {"a", "c"}]


### PR DESCRIPTION
## Summary

- Persist each successfully sent listing immediately instead of waiting for the full Telegram batch to complete.
- Continue sending later listings if one Telegram send fails.
- Add a regression test covering partial delivery failure so successful messages are not duplicated on the next scan.
- Move cron registration behind `main()` so importing `scan.py` does not register scheduled work or emit the aiocron event-loop warning.

## Validation

- `/tmp/berlinhome-venv/bin/pytest -q`
