### PR TITLE
[codex] Enable additional provider scanners

### DIFF
--- a/scan.py
+++ b/scan.py
@@ -26,9 +26,11 @@ import html
 import logging
 import os
 import pickle
+import re
 import signal
 from datetime import datetime, timezone
 from typing import Any, Dict, List, TypedDict
+from urllib.parse import parse_qs, urljoin, urlparse
 
 import aiohttp
 import aiocron
@@ -43,7 +45,7 @@ from telegram.constants import ParseMode
 CRON_SCHEDULE = "*/2 * * * *"    # every two minutes
 MIN_ROOMS = 2.5
 MIN_SQM = 62
-MAX_RENT_INBERLIN = 1600         # €
+MAX_RENT = 1600                  # €
 
 STATE_FILE = os.getenv("STATE_FILE", "./notified.pkl")
 
@@ -58,6 +60,20 @@ HEADERS = {
 }
 
 GEWOBAG_TIMEOUT = 15_000  # ms
+DEGEWO_MAX_PAGES = 10
+
+GESOBAU_URL = (
+    "https://www.gesobau.de/mieten/wohnungssuche/"
+    "?resultsPerPage=10000"
+    "&resultsPage=0"
+    "&resultAsJSON=1"
+    "&befilter%5B0%5D=nutzungsart_stringS%3AWOHNEN"
+    "&befilter%5B1%5D=kanal_stringM%3A%28%22Service%22+OR+%22Senioren+Kachel%22+"
+    "OR+%22Bestand%22+OR+%22Studierende%22+OR+%22Neubau+Kachel%22%29"
+)
+HOWOGE_URL = "https://www.howoge.de/?type=999&tx_howrealestate_json_list%5Baction%5D=immoList"
+DEGEWO_URL = "https://www.degewo.de/immosuche"
+INBERLIN_DUPLICATE_DOMAINS = ("wbm.de", "degewo.de", "gesobau.de", "howoge.de")
 
 # ───────────────────────────  LOGGING  ──────────────────────────── #
 
@@ -144,6 +160,31 @@ async def fetch(url: str, *, params: Dict[str, Any] | None = None, timeout: int 
         log.warning("Fetch error %s → %s", url, exc)
         return ""
 
+
+async def fetch_json(
+    url: str,
+    *,
+    data: Dict[str, Any] | None = None,
+    params: Dict[str, Any] | None = None,
+    timeout: int = 12,
+) -> Any | None:
+    session = await ensure_session()
+    headers = {**HEADERS, "X-Requested-With": "XMLHttpRequest"}
+    try:
+        if data is None:
+            async with session.get(
+                url, params=params, headers=headers, timeout=timeout
+            ) as r:
+                r.raise_for_status()
+                return await r.json(content_type=None)
+        async with session.post(url, data=data, headers=headers, timeout=timeout) as r:
+            r.raise_for_status()
+            return await r.json(content_type=None)
+    except (aiohttp.ClientError, asyncio.TimeoutError, ValueError) as exc:
+        log.warning("Fetch JSON error %s → %s", url, exc)
+        return None
+
+
 class Listing(TypedDict):
     id: str
     rooms: float
@@ -153,6 +194,51 @@ class Listing(TypedDict):
     title: str | None
     address: str | None
     provider: str
+
+
+def _parse_number(value: Any) -> float | None:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if value is None:
+        return None
+
+    text = html.unescape(str(value)).replace("\xa0", " ").replace("\u202f", " ")
+    match = re.search(r"\d+(?:[.,]\d{3})*(?:[.,]\d+)?|\d+", text)
+    if not match:
+        return None
+
+    number = match.group(0)
+    if "," in number and "." in number:
+        number = number.replace(".", "").replace(",", ".")
+    elif "," in number:
+        number = number.replace(",", ".")
+    try:
+        return float(number)
+    except ValueError:
+        return None
+
+
+def _passes_size_filter(rooms: float | None, sqm: float | None) -> bool:
+    return rooms is not None and sqm is not None and rooms >= MIN_ROOMS and sqm >= MIN_SQM
+
+
+def _passes_rent_filter(value: Any) -> bool:
+    rent = _parse_number(value)
+    return rent is None or rent <= MAX_RENT
+
+
+def _rent_text(value: Any) -> str | None:
+    rent = _parse_number(value)
+    if rent is None:
+        return None
+    return f"{rent:.2f}".rstrip("0").rstrip(".")
+
+
+def _text_or_none(node: Any) -> str | None:
+    if not node:
+        return None
+    text = node.get_text(" ", strip=True)
+    return text or None
 
 # ──────────────────────────  SCANNERS  ───────────────────────────── #
 
@@ -198,11 +284,10 @@ async def scan_gewobag() -> List[Listing]:
                     rooms_txt, sqm_txt = [s.strip() for s in area.split("|")]
                     rooms = float(rooms_txt.split()[0].replace(",", "."))
                     sqm = float(sqm_txt.replace("m²", "").replace(",", "."))
-                    if rooms < MIN_ROOMS or sqm < MIN_SQM:
+                    if not _passes_size_filter(rooms, sqm):
                         continue
                     link = art.select_one("a.read-more-link")["href"]
                     if not link.startswith("http"):
-                        from urllib.parse import urljoin
                         link = urljoin("https://www.gewobag.de", link)
                     listings.append(
                         Listing(
@@ -223,6 +308,7 @@ async def scan_gewobag() -> List[Listing]:
     log.info("[Gewobag] %d listings", len(listings))
     return listings
 
+
 async def scan_wbm() -> List[Listing]:
     html = await fetch("https://www.wbm.de/wohnungen-berlin/angebote/")
     if not html:
@@ -234,7 +320,7 @@ async def scan_wbm() -> List[Listing]:
             rooms = float(div.select_one("div.main-property-rooms").text.strip().replace(",", "."))
             sqm = float(div.select_one("div.main-property-size").text
                         .replace("m²", "").replace(",", ".").strip())
-            if rooms < MIN_ROOMS or sqm < MIN_SQM:
+            if not _passes_size_filter(rooms, sqm):
                 continue
             link = div.find("a", title="Details")["href"]
             if not link.startswith("http"):
@@ -257,6 +343,7 @@ async def scan_wbm() -> List[Listing]:
     log.info("[WBM] %d listings", len(listings))
     return listings
 
+
 async def scan_inberlinwohnen() -> List[Listing]:
     html = await fetch("https://inberlinwohnen.de/wohnungsfinder/")
     if not html:
@@ -276,13 +363,13 @@ async def scan_inberlinwohnen() -> List[Listing]:
             sqm = float(st[1].text.replace(",", "."))
             rent_val = float(st[2].text.replace("€", "").replace("ab", "")
                              .replace(".", "").replace(",", "."))
-            if rooms < 3 or rent_val > MAX_RENT_INBERLIN:
+            if not _passes_size_filter(rooms, sqm) or rent_val > MAX_RENT:
                 continue
             link = li.find("a", title=lambda t: t and "detailierte" in t)["href"]
             if not link.startswith("http"):
                 link = "https://inberlinwohnen.de" + link
-            if "wbm.de" in link:
-                continue  # skip WBM entries to avoid duplicates
+            if any(domain in link for domain in INBERLIN_DUPLICATE_DOMAINS):
+                continue  # skip entries covered by direct provider scanners
             listings.append(
                 Listing(
                     id=f"inberlinwohnen_{lid}",
@@ -300,19 +387,214 @@ async def scan_inberlinwohnen() -> List[Listing]:
     log.info("[inberlinwohnen] %d listings", len(listings))
     return listings
 
-# stubs – add real scrapers later
-async def scan_gesobau() -> List[Listing]:     return []
-async def scan_degewo() -> List[Listing]:      return []
-async def scan_howoge() -> List[Listing]:      return []
-async def scan_stadtundland() -> List[Listing]:return []
+
+async def scan_gesobau() -> List[Listing]:
+    data = await fetch_json(GESOBAU_URL)
+    if not isinstance(data, list):
+        return []
+
+    listings: List[Listing] = []
+    for item in data:
+        try:
+            raw = item.get("raw") or {}
+            rooms = _parse_number(raw.get("zimmer_intS"))
+            sqm = _parse_number(raw.get("wohnflaeche_floatS"))
+
+            detail = raw.get("url") or item.get("detail") or ""
+            link = urljoin("https://www.gesobau.de", detail)
+            if rooms is None and link:
+                rooms = await _fetch_gesobau_detail_rooms(link)
+            if not _passes_size_filter(rooms, sqm):
+                continue
+            if not _passes_rent_filter(raw.get("warmmiete_floatS")):
+                continue
+
+            address_parts = [
+                raw.get("adresse_stringS") or item.get("title"),
+                raw.get("plz_stringS"),
+                raw.get("ort_stringS"),
+            ]
+            address = ", ".join(str(part) for part in address_parts if part)
+            title = raw.get("title") or item.get("title")
+            lid = raw.get("objekt_nr_extern_stringS") or item.get("uid")
+            listings.append(
+                Listing(
+                    id=f"gesobau_{lid}",
+                    rooms=rooms,
+                    sqm=sqm,
+                    link=link,
+                    rent=_rent_text(raw.get("warmmiete_floatS")),
+                    title=title,
+                    address=address or None,
+                    provider="GESOBAU",
+                )
+            )
+        except Exception:
+            log.debug("GESOBAU parse error", exc_info=True)
+    log.info("[GESOBAU] %d listings", len(listings))
+    return listings
+
+
+async def _fetch_gesobau_detail_rooms(link: str) -> float | None:
+    html_text = await fetch(link)
+    if not html_text:
+        return None
+    soup = BeautifulSoup(html_text, "lxml")
+    match = re.search(
+        r"(\d+(?:[,.]\d+)?)\s*Zimmer",
+        soup.get_text(" ", strip=True),
+        re.IGNORECASE,
+    )
+    if not match:
+        return None
+    return _parse_number(match.group(1))
+
+
+async def scan_degewo() -> List[Listing]:
+    listings: List[Listing] = []
+    seen_ids: set[str] = set()
+    next_url: str | None = DEGEWO_URL
+    seen_urls: set[str] = set()
+
+    for _ in range(DEGEWO_MAX_PAGES):
+        if not next_url or next_url in seen_urls:
+            break
+        seen_urls.add(next_url)
+        html_text = await fetch(next_url)
+        if not html_text:
+            break
+
+        soup = BeautifulSoup(html_text, "lxml")
+        for listing in _parse_degewo_page(soup):
+            if listing["id"] in seen_ids:
+                continue
+            seen_ids.add(listing["id"])
+            listings.append(listing)
+
+        current_page = _degewo_page_number(next_url)
+        next_url = _next_degewo_page_url(soup, current_page)
+
+    log.info("[degewo] %d listings", len(listings))
+    return listings
+
+
+def _parse_degewo_page(soup: BeautifulSoup) -> List[Listing]:
+    listings: List[Listing] = []
+    for card in soup.select("div.c-teaser.c-teaser--apartment"):
+        try:
+            facts: Dict[str, str] = {}
+            for item in card.select(".c-definition-list__item"):
+                value = _text_or_none(item.select_one("dt"))
+                label = _text_or_none(item.select_one("dd"))
+                if value and label:
+                    facts[label] = value
+
+            rooms = _parse_number(facts.get("Zimmer"))
+            sqm = _parse_number(facts.get("m²"))
+            if not _passes_size_filter(rooms, sqm):
+                continue
+            if not _passes_rent_filter(facts.get("Warmmiete")):
+                continue
+
+            link_node = card.select_one("h3 a[href]")
+            if not link_node:
+                continue
+            link = urljoin("https://www.degewo.de", link_node["href"])
+            bookmark = card.select_one("[data-openimmo-bookmark-item-uid]")
+            lid = (
+                bookmark.get("data-openimmo-bookmark-item-uid")
+                if bookmark
+                else link.rstrip("/").split("/")[-1]
+            )
+            listings.append(
+                Listing(
+                    id=f"degewo_{lid}",
+                    rooms=rooms,
+                    sqm=sqm,
+                    link=link,
+                    rent=facts.get("Warmmiete"),
+                    title=_text_or_none(link_node),
+                    address=_text_or_none(card.select_one("h3 + p")),
+                    provider="degewo",
+                )
+            )
+        except Exception:
+            log.debug("degewo parse error", exc_info=True)
+    return listings
+
+
+def _degewo_page_number(url: str) -> int:
+    query = parse_qs(urlparse(url).query)
+    value = query.get("tx_openimmo_immobilie[page]")
+    if not value:
+        return 1
+    try:
+        return int(value[0])
+    except ValueError:
+        return 1
+
+
+def _next_degewo_page_url(soup: BeautifulSoup, current_page: int) -> str | None:
+    target = current_page + 1
+    for link in soup.select("a[href]"):
+        url = urljoin("https://www.degewo.de", link["href"])
+        if _degewo_page_number(url) == target:
+            return url
+    return None
+
+
+async def scan_howoge() -> List[Listing]:
+    data = await fetch_json(
+        HOWOGE_URL,
+        data={
+            "tx_howrealestate_json_list[page]": 1,
+            "tx_howrealestate_json_list[limit]": 500,
+            "tx_howrealestate_json_list[lang]": "",
+        },
+    )
+    if not isinstance(data, dict):
+        return []
+
+    listings: List[Listing] = []
+    for item in data.get("immoobjects", []):
+        try:
+            rooms = _parse_number(item.get("rooms"))
+            sqm = _parse_number(item.get("area"))
+            if not _passes_size_filter(rooms, sqm):
+                continue
+            if not _passes_rent_filter(item.get("rent")):
+                continue
+
+            link = urljoin("https://www.howoge.de", item.get("link") or "")
+            title = str(item.get("notice") or "").strip() or None
+            listings.append(
+                Listing(
+                    id=f"howoge_{item['uid']}",
+                    rooms=rooms,
+                    sqm=sqm,
+                    link=link,
+                    rent=_rent_text(item.get("rent")),
+                    title=title or item.get("title"),
+                    address=item.get("title") or item.get("district"),
+                    provider="HOWOGE",
+                )
+            )
+        except Exception:
+            log.debug("HOWOGE parse error", exc_info=True)
+    log.info("[HOWOGE] %d listings", len(listings))
+    return listings
+
+
+async def scan_stadtundland() -> List[Listing]:
+    return []
 
 SCANNERS = [
     scan_gewobag,
     scan_wbm,
     scan_inberlinwohnen,
-    # scan_gesobau,
-    # scan_degewo,
-    # scan_howoge,
+    scan_gesobau,
+    scan_degewo,
+    scan_howoge,
     # scan_stadtundland,
 ]
 
@@ -413,14 +695,7 @@ async def job() -> None:
         log.warning("Previous run still active — skipping")
         return
     async with JOB_LOCK:
-        # decide dynamically which scanners to call
-        scanners = [
-            scan_gewobag,
-            scan_wbm,
-            scan_inberlinwohnen
-        ]
-
-        tasks = [asyncio.create_task(scan()) for scan in scanners]
+        tasks = [asyncio.create_task(scan()) for scan in SCANNERS]
         flat: List[Listing] = []
         for coro in asyncio.as_completed(tasks):
             listings = await coro

--- a/scan.py
+++ b/scan.py
@@ -203,7 +203,7 @@ def _parse_number(value: Any) -> float | None:
         return None
 
     text = html.unescape(str(value)).replace("\xa0", " ").replace("\u202f", " ")
-    match = re.search(r"\d+(?:[.,]\d{3})*(?:[.,]\d+)?|\d+", text)
+    match = re.search(r"\d+(?:[.,]\d+)*", text)
     if not match:
         return None
 
@@ -212,6 +212,10 @@ def _parse_number(value: Any) -> float | None:
         number = number.replace(".", "").replace(",", ".")
     elif "," in number:
         number = number.replace(",", ".")
+    elif "." in number:
+        parts = number.split(".")
+        if len(parts) > 1 and all(len(part) == 3 for part in parts[1:]):
+            number = "".join(parts)
     try:
         return float(number)
     except ValueError:
@@ -223,6 +227,7 @@ def _passes_size_filter(rooms: float | None, sqm: float | None) -> bool:
 
 
 def _passes_rent_filter(value: Any) -> bool:
+    # Missing rent should not hide otherwise valid listings.
     rent = _parse_number(value)
     return rent is None or rent <= MAX_RENT
 
@@ -231,7 +236,10 @@ def _rent_text(value: Any) -> str | None:
     rent = _parse_number(value)
     if rent is None:
         return None
-    return f"{rent:.2f}".rstrip("0").rstrip(".")
+    if rent.is_integer():
+        return f"{int(rent):,}".replace(",", ".")
+    euros, cents = f"{rent:,.2f}".split(".")
+    return f"{euros.replace(',', '.')},{cents}"
 
 
 def _text_or_none(node: Any) -> str | None:
@@ -363,7 +371,7 @@ async def scan_inberlinwohnen() -> List[Listing]:
             sqm = float(st[1].text.replace(",", "."))
             rent_val = float(st[2].text.replace("€", "").replace("ab", "")
                              .replace(".", "").replace(",", "."))
-            if not _passes_size_filter(rooms, sqm) or rent_val > MAX_RENT:
+            if rooms < 3 or rent_val > MAX_RENT:
                 continue
             link = li.find("a", title=lambda t: t and "detailierte" in t)["href"]
             if not link.startswith("http"):
@@ -399,14 +407,16 @@ async def scan_gesobau() -> List[Listing]:
             raw = item.get("raw") or {}
             rooms = _parse_number(raw.get("zimmer_intS"))
             sqm = _parse_number(raw.get("wohnflaeche_floatS"))
+            if not _passes_rent_filter(raw.get("warmmiete_floatS")):
+                continue
+            if sqm is None or sqm < MIN_SQM:
+                continue
 
             detail = raw.get("url") or item.get("detail") or ""
             link = urljoin("https://www.gesobau.de", detail)
             if rooms is None and link:
                 rooms = await _fetch_gesobau_detail_rooms(link)
             if not _passes_size_filter(rooms, sqm):
-                continue
-            if not _passes_rent_filter(raw.get("warmmiete_floatS")):
                 continue
 
             address_parts = [
@@ -440,9 +450,10 @@ async def _fetch_gesobau_detail_rooms(link: str) -> float | None:
     if not html_text:
         return None
     soup = BeautifulSoup(html_text, "lxml")
+    meta = soup.select_one(".immoHero__metaData") or soup
     match = re.search(
         r"(\d+(?:[,.]\d+)?)\s*Zimmer",
-        soup.get_text(" ", strip=True),
+        meta.get_text(" ", strip=True),
         re.IGNORECASE,
     )
     if not match:
@@ -484,6 +495,7 @@ def _parse_degewo_page(soup: BeautifulSoup) -> List[Listing]:
         try:
             facts: Dict[str, str] = {}
             for item in card.select(".c-definition-list__item"):
+                # degewo renders the fact value in dt and its label in dd.
                 value = _text_or_none(item.select_one("dt"))
                 label = _text_or_none(item.select_one("dd"))
                 if value and label:
@@ -512,7 +524,7 @@ def _parse_degewo_page(soup: BeautifulSoup) -> List[Listing]:
                     rooms=rooms,
                     sqm=sqm,
                     link=link,
-                    rent=facts.get("Warmmiete"),
+                    rent=_rent_text(facts.get("Warmmiete")),
                     title=_text_or_none(link_node),
                     address=_text_or_none(card.select_one("h3 + p")),
                     provider="degewo",
@@ -567,6 +579,8 @@ async def scan_howoge() -> List[Listing]:
 
             link = urljoin("https://www.howoge.de", item.get("link") or "")
             title = str(item.get("notice") or "").strip() or None
+            # HOWOGE's current list payload uses title for the street address.
+            address = item.get("title") or item.get("district")
             listings.append(
                 Listing(
                     id=f"howoge_{item['uid']}",
@@ -575,7 +589,7 @@ async def scan_howoge() -> List[Listing]:
                     link=link,
                     rent=_rent_text(item.get("rent")),
                     title=title or item.get("title"),
-                    address=item.get("title") or item.get("district"),
+                    address=address,
                     provider="HOWOGE",
                 )
             )

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -288,10 +288,161 @@ def test_scan_inberlinwohnen_skip_wbm(monkeypatch):
     assert listings == []
 
 
-def test_scan_stubs():
-    assert asyncio.run(scan.scan_gesobau()) == []
-    assert asyncio.run(scan.scan_degewo()) == []
-    assert asyncio.run(scan.scan_howoge()) == []
+def test_parse_number_handles_german_formats():
+    assert scan._parse_number("1.179,98 €") == 1179.98
+    assert scan._parse_number("2,5 Zimmer") == 2.5
+    assert scan._parse_number("70.5 m²") == 70.5
+    assert scan._parse_number(None) is None
+    assert scan._passes_rent_filter("1.600,00 €")
+    assert not scan._passes_rent_filter("1.600,01 €")
+
+
+def test_scan_gesobau(monkeypatch):
+    payload = [
+        {
+            "uid": 1,
+            "detail": "/detail/large",
+            "title": "Gerichtstraße 13",
+            "raw": {
+                "objekt_nr_extern_stringS": "obj-1",
+                "url": "/detail/large",
+                "title": "Große Wohnung",
+                "adresse_stringS": "Gerichtstraße 13",
+                "plz_stringS": "13347",
+                "ort_stringS": "Berlin",
+                "wohnflaeche_floatS": "70,5",
+                "warmmiete_floatS": "1.179,98",
+            },
+        },
+        {
+            "uid": 2,
+            "detail": "/detail/small",
+            "title": "Kleine Wohnung",
+            "raw": {
+                "objekt_nr_extern_stringS": "obj-2",
+                "zimmer_intS": 2,
+                "wohnflaeche_floatS": 80,
+            },
+        },
+    ]
+
+    async def fake_fetch_json(url, *, data=None, params=None, timeout=12):
+        return payload
+
+    async def fake_fetch(url, *, params=None, timeout=12):
+        return "<p>2,5 Zimmer</p>"
+
+    monkeypatch.setattr(scan, "fetch_json", fake_fetch_json)
+    monkeypatch.setattr(scan, "fetch", fake_fetch)
+
+    listings = asyncio.run(scan.scan_gesobau())
+
+    assert listings == [
+        {
+            "id": "gesobau_obj-1",
+            "rooms": 2.5,
+            "sqm": 70.5,
+            "link": "https://www.gesobau.de/detail/large",
+            "rent": "1179.98",
+            "title": "Große Wohnung",
+            "address": "Gerichtstraße 13, 13347, Berlin",
+            "provider": "GESOBAU",
+        }
+    ]
+
+
+def test_scan_degewo(monkeypatch):
+    first_page = """
+    <div class='c-teaser c-teaser--apartment'>
+        <button data-openimmo-bookmark-item-uid='W-small'></button>
+        <h3><a href='/immosuche/details/small'>Klein</a></h3>
+        <p>Adresse 1 | Kiez</p>
+        <div class='c-definition-list__item'><dt>524,12 €</dt><dd>Warmmiete</dd></div>
+        <div class='c-definition-list__item'><dt>1</dt><dd>Zimmer</dd></div>
+        <div class='c-definition-list__item'><dt>39,67</dt><dd>m²</dd></div>
+    </div>
+    <a href='/immosuche?tx_openimmo_immobilie%5Bpage%5D=2&tx_openimmo_immobilie%5Bsearch%5D=paginate#immo-teaser-list'>2</a>
+    """
+    second_page = """
+    <div class='c-teaser c-teaser--apartment'>
+        <button data-openimmo-bookmark-item-uid='W-large'></button>
+        <h3><a href='/immosuche/details/large'>Große Wohnung</a></h3>
+        <p>Adresse 2 | Kiez</p>
+        <div class='c-definition-list__item'><dt>1.250,50 €</dt><dd>Warmmiete</dd></div>
+        <div class='c-definition-list__item'><dt>3</dt><dd>Zimmer</dd></div>
+        <div class='c-definition-list__item'><dt>72,5</dt><dd>m²</dd></div>
+    </div>
+    """
+
+    async def fake_fetch(url, *, params=None, timeout=12):
+        if "page%5D=2" in url:
+            return second_page
+        return first_page
+
+    monkeypatch.setattr(scan, "fetch", fake_fetch)
+
+    listings = asyncio.run(scan.scan_degewo())
+
+    assert listings == [
+        {
+            "id": "degewo_W-large",
+            "rooms": 3.0,
+            "sqm": 72.5,
+            "link": "https://www.degewo.de/immosuche/details/large",
+            "rent": "1.250,50 €",
+            "title": "Große Wohnung",
+            "address": "Adresse 2 | Kiez",
+            "provider": "degewo",
+        }
+    ]
+
+
+def test_scan_howoge(monkeypatch):
+    payload = {
+        "immoobjects": [
+            {
+                "uid": 7094,
+                "title": "Streitstraße 5, 13587 Berlin",
+                "district": "Hakenfelde",
+                "rent": 803,
+                "area": 73,
+                "rooms": 3,
+                "link": "/immobiliensuche/wohnungssuche/detail/1771-14536-9997.html",
+                "notice": " 3-Zimmer-Wohnung (WBS 100-140)",
+            },
+            {
+                "uid": 7095,
+                "title": "Kleine Wohnung",
+                "rent": 500,
+                "area": 40,
+                "rooms": 1,
+                "link": "/small.html",
+            },
+        ]
+    }
+
+    async def fake_fetch_json(url, *, data=None, params=None, timeout=12):
+        return payload
+
+    monkeypatch.setattr(scan, "fetch_json", fake_fetch_json)
+
+    listings = asyncio.run(scan.scan_howoge())
+
+    assert listings == [
+        {
+            "id": "howoge_7094",
+            "rooms": 3.0,
+            "sqm": 73.0,
+            "link": "https://www.howoge.de/immobiliensuche/wohnungssuche/detail/1771-14536-9997.html",
+            "rent": "803",
+            "title": "3-Zimmer-Wohnung (WBS 100-140)",
+            "address": "Streitstraße 5, 13587 Berlin",
+            "provider": "HOWOGE",
+        }
+    ]
+
+
+def test_scan_stadtundland_stub():
     assert asyncio.run(scan.scan_stadtundland()) == []
 
 

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -288,16 +288,42 @@ def test_scan_inberlinwohnen_skip_wbm(monkeypatch):
     assert listings == []
 
 
+def test_scan_inberlinwohnen_keeps_legacy_room_filter(monkeypatch):
+    html = """
+    <ul id='_tb_relevant_results'>
+        <li id='b3' class='tb-merkflat'>
+            <a title='detailierte Ansicht' href='/b3detail'>Link</a>
+            <h3>Compact three-room flat</h3>
+            <strong>3</strong>
+            <strong>55</strong>
+            <strong>ab 1200 €</strong>
+        </li>
+    </ul>
+    """
+
+    async def fake_fetch(url, *, params=None, timeout=12):
+        return html
+
+    monkeypatch.setattr(scan, "fetch", fake_fetch)
+    listings = asyncio.run(scan.scan_inberlinwohnen())
+
+    assert listings and listings[0]["id"] == "inberlinwohnen_b3"
+
+
 def test_parse_number_handles_german_formats():
     assert scan._parse_number("1.179,98 €") == 1179.98
+    assert scan._parse_number("1.234 €") == 1234.0
+    assert scan._parse_number("1.234.567 €") == 1234567.0
     assert scan._parse_number("2,5 Zimmer") == 2.5
     assert scan._parse_number("70.5 m²") == 70.5
     assert scan._parse_number(None) is None
     assert scan._passes_rent_filter("1.600,00 €")
     assert not scan._passes_rent_filter("1.600,01 €")
+    assert scan._rent_text("1.179,98 €") == "1.179,98"
 
 
 def test_scan_gesobau(monkeypatch):
+    detail_fetches = []
     payload = [
         {
             "uid": 1,
@@ -324,12 +350,23 @@ def test_scan_gesobau(monkeypatch):
                 "wohnflaeche_floatS": 80,
             },
         },
+        {
+            "uid": 3,
+            "detail": "/detail/missing-size",
+            "title": "No size",
+            "raw": {
+                "objekt_nr_extern_stringS": "obj-3",
+                "url": "/detail/missing-size",
+                "warmmiete_floatS": 900,
+            },
+        },
     ]
 
     async def fake_fetch_json(url, *, data=None, params=None, timeout=12):
         return payload
 
     async def fake_fetch(url, *, params=None, timeout=12):
+        detail_fetches.append(url)
         return "<p>2,5 Zimmer</p>"
 
     monkeypatch.setattr(scan, "fetch_json", fake_fetch_json)
@@ -343,12 +380,29 @@ def test_scan_gesobau(monkeypatch):
             "rooms": 2.5,
             "sqm": 70.5,
             "link": "https://www.gesobau.de/detail/large",
-            "rent": "1179.98",
+            "rent": "1.179,98",
             "title": "Große Wohnung",
             "address": "Gerichtstraße 13, 13347, Berlin",
             "provider": "GESOBAU",
         }
     ]
+    assert detail_fetches == ["https://www.gesobau.de/detail/large"]
+
+
+def test_fetch_gesobau_detail_rooms_uses_hero_metadata(monkeypatch):
+    html = """
+    <nav>Wohnungen ab 1 Zimmer</nav>
+    <ul class='immoHero__metaData'>
+        <li>2,5 Zimmer</li>
+    </ul>
+    """
+
+    async def fake_fetch(url, *, params=None, timeout=12):
+        return html
+
+    monkeypatch.setattr(scan, "fetch", fake_fetch)
+
+    assert asyncio.run(scan._fetch_gesobau_detail_rooms("https://example.com")) == 2.5
 
 
 def test_scan_degewo(monkeypatch):
@@ -389,7 +443,7 @@ def test_scan_degewo(monkeypatch):
             "rooms": 3.0,
             "sqm": 72.5,
             "link": "https://www.degewo.de/immosuche/details/large",
-            "rent": "1.250,50 €",
+            "rent": "1.250,50",
             "title": "Große Wohnung",
             "address": "Adresse 2 | Kiez",
             "provider": "degewo",


### PR DESCRIPTION
## Summary
- Adds active scanners for GESOBAU, degewo, and HOWOGE using their current public JSON/HTML listing surfaces.
- Applies the same 1600 EUR rent cap to direct provider feeds when rent is available, and skips inBerlinWohnen entries for providers now scanned directly to reduce duplicate notifications.
- Switches the scheduled job to use the shared `SCANNERS` registry and adds fixture-driven tests for the new parsers.
- Addresses review feedback by preserving inBerlinWohnen's legacy rooms/rent filter, normalizing rent display text, tightening German number parsing, and constraining the GESOBAU detail fallback selector.

## Validation
- `/tmp/berlinhome-venv/bin/pytest -q`
- `TELEGRAM_BOT_TOKEN=dummy TELEGRAM_USER_ID=dummy /tmp/berlinhome-venv/bin/python -m py_compile scan.py tests/test_scan.py`
- Live smoke of new scanners on 2026-05-21: GESOBAU 0 matches after rent cap, degewo 8 matches, HOWOGE 14 matches.
- GESOBAU sanity check on 2026-05-21: endpoint returned 9 raw entries; the only size-relevant candidate was 102.83 sqm with 2344.67 EUR warm rent, so it is correctly excluded by the 1600 EUR cap.

## Notes
- STADT UND LAND is still inactive because the public page currently routes into a PlanNet/login-style flow instead of a stable public listing feed.
