### PR TITLE
[codex] Filter listings by preferred Berlin areas

### DIFF
--- a/scan.py
+++ b/scan.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import html
+import json
 import logging
 import math
 import os
@@ -280,6 +281,17 @@ def _text_or_none(node: Any) -> str | None:
     return text or None
 
 
+def _location_texts_or_fallback(source: Any, texts: List[Any], provider: str) -> List[Any]:
+    if any(text for text in texts):
+        return texts
+    fallback = _text_or_none(source)
+    if fallback:
+        log.warning("[%s] location selectors empty; using card text fallback", provider)
+        return [fallback]
+    log.warning("[%s] location selectors empty; dropping listing", provider)
+    return []
+
+
 def _normalize_location_text(value: Any) -> str:
     text = unicodedata.normalize("NFKD", html.unescape(str(value or "")))
     text = "".join(ch for ch in text if not unicodedata.combining(ch))
@@ -291,7 +303,7 @@ def _contains_location_term(text: str, term: str) -> bool:
 
 
 def _extract_zip(text: str) -> str | None:
-    match = re.search(r"\b1\d{4}\b", text)
+    match = re.search(r"\b1[0-4]\d{3}\b", text)
     return match.group(0) if match else None
 
 
@@ -376,10 +388,13 @@ async def scan_gewobag() -> List[Listing]:
                     sqm = float(sqm_txt.replace("m²", "").replace(",", "."))
                     if not _passes_size_filter(rooms, sqm):
                         continue
-                    location_texts = [
-                        art.select_one("address").get_text(" ", strip=True),
-                        art.select_one("h3.angebot-title").get_text(" ", strip=True),
-                    ]
+                    title = _text_or_none(art.select_one("h3.angebot-title"))
+                    address = _text_or_none(art.select_one("address"))
+                    location_texts = _location_texts_or_fallback(
+                        art,
+                        [address, title],
+                        "Gewobag",
+                    )
                     if not _location_matches(location_texts):
                         continue
                     link = art.select_one("a.read-more-link")["href"]
@@ -392,8 +407,8 @@ async def scan_gewobag() -> List[Listing]:
                             sqm=sqm,
                             link=link,
                             rent=None,
-                            title=art.select_one("h3.angebot-title").get_text(strip=True),
-                            address=art.select_one("address").get_text(strip=True),
+                            title=title,
+                            address=address,
                             provider="Gewobag",
                         )
                     )
@@ -413,15 +428,20 @@ async def scan_wbm() -> List[Listing]:
     listings: List[Listing] = []
     for div in soup.select("div.row.openimmo-search-list-item"):
         try:
-            area = _text_or_none(div.select_one(".area"))
-            address = _text_or_none(div.select_one(".address"))
-            title = _text_or_none(div.select_one("h2.imageTitle"))
-            if not _location_matches([area, address, title]):
-                continue
             rooms = float(div.select_one("div.main-property-rooms").text.strip().replace(",", "."))
             sqm = float(div.select_one("div.main-property-size").text
                         .replace("m²", "").replace(",", ".").strip())
             if not _passes_size_filter(rooms, sqm):
+                continue
+            area = _text_or_none(div.select_one(".area"))
+            address = _text_or_none(div.select_one(".address"))
+            title = _text_or_none(div.select_one("h2.imageTitle"))
+            location_texts = _location_texts_or_fallback(
+                div,
+                [area, address, title],
+                "WBM",
+            )
+            if not _location_matches(location_texts):
                 continue
             link = div.find("a", title="Details")["href"]
             if not link.startswith("http"):
@@ -446,13 +466,21 @@ async def scan_wbm() -> List[Listing]:
 
 
 async def scan_inberlinwohnen() -> List[Listing]:
-    html = await fetch("https://inberlinwohnen.de/wohnungsfinder/")
-    if not html:
+    html_text = await fetch("https://inberlinwohnen.de/wohnungsfinder/")
+    if not html_text:
         return []
-    soup = BeautifulSoup(html, "lxml")
+    soup = BeautifulSoup(html_text, "lxml")
     ul = soup.find("ul", id="_tb_relevant_results")
-    if not ul:
-        return []
+    listings: List[Listing] = []
+    if ul:
+        listings = _parse_inberlinwohnen_legacy(ul)
+    else:
+        listings = _parse_inberlinwohnen_livewire(soup)
+    log.info("[inberlinwohnen] %d listings", len(listings))
+    return listings
+
+
+def _parse_inberlinwohnen_legacy(ul: Any) -> List[Listing]:
     listings: List[Listing] = []
     for li in ul.select("li.tb-merkflat"):
         try:
@@ -466,8 +494,16 @@ async def scan_inberlinwohnen() -> List[Listing]:
                              .replace(".", "").replace(",", "."))
             if rooms < 3 or rent_val > MAX_RENT:
                 continue
-            title = li.find("h3").get_text(strip=True)
-            if not _location_matches([title]):
+            title = _text_or_none(li.find("h3"))
+            address = _text_or_none(li.select_one(
+                "address, .address, .tb-address, [class*='address'], [class*='Address']"
+            ))
+            location_texts = _location_texts_or_fallback(
+                li,
+                [title, address],
+                "inBerlinWohnen",
+            )
+            if not _location_matches(location_texts):
                 continue
             link = li.find("a", title=lambda t: t and "detailierte" in t)["href"]
             if not link.startswith("http"):
@@ -482,13 +518,96 @@ async def scan_inberlinwohnen() -> List[Listing]:
                     link=link,
                     rent=f"{rent_val:.0f}",
                     title=title,
-                    address=None,
+                    address=address,
                     provider="inBerlinWohnen",
                 )
             )
         except Exception:
             log.debug("inBerlin parse error", exc_info=True)
-    log.info("[inberlinwohnen] %d listings", len(listings))
+    return listings
+
+
+def _decode_livewire_value(value: Any) -> Any:
+    if isinstance(value, list):
+        if len(value) == 2 and isinstance(value[1], dict) and "s" in value[1]:
+            return _decode_livewire_value(value[0])
+        return [_decode_livewire_value(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _decode_livewire_value(item) for key, item in value.items()}
+    return value
+
+
+def _inberlin_address_text(address: Dict[str, Any]) -> str | None:
+    street_line = " ".join(
+        str(part).strip()
+        for part in (address.get("street"), address.get("number"))
+        if part
+    )
+    parts = [street_line, address.get("zipCode"), address.get("district")]
+    text = ", ".join(str(part).strip() for part in parts if part)
+    return text or None
+
+
+def _parse_inberlinwohnen_livewire(soup: BeautifulSoup) -> List[Listing]:
+    listings: List[Listing] = []
+    seen_ids: set[str] = set()
+    for node in soup.find_all(attrs={"wire:snapshot": True}):
+        snapshot_raw = node.get("wire:snapshot")
+        if not snapshot_raw:
+            continue
+        try:
+            snapshot = json.loads(html.unescape(str(snapshot_raw)))
+            item = _decode_livewire_value((snapshot.get("data") or {}).get("item"))
+            if not isinstance(item, dict) or not item.get("deeplink"):
+                continue
+
+            rooms = _parse_number(item.get("rooms"))
+            sqm = _parse_number(item.get("area"))
+            rent_val = _parse_number(item.get("rentGross"))
+            if rooms is None or sqm is None or rent_val is None:
+                continue
+            if rooms < 3 or rent_val > MAX_RENT:
+                continue
+
+            address_data = _decode_livewire_value(item.get("address"))
+            if not isinstance(address_data, dict):
+                address_data = {}
+            address = _inberlin_address_text(address_data)
+            coords = _parse_coords(address_data.get("lat"), address_data.get("lon"))
+            title = str(item.get("title") or "").strip() or None
+            location_texts = [
+                title,
+                address,
+                address_data.get("zipCode"),
+                address_data.get("district"),
+            ]
+            if not _location_matches(location_texts, coords):
+                continue
+
+            link = urljoin("https://inberlinwohnen.de", str(item.get("deeplink")))
+            if any(domain in link for domain in INBERLIN_DUPLICATE_DOMAINS):
+                continue  # skip entries covered by direct provider scanners
+            raw_id = item.get("id") or item.get("objectId") or hashlib.sha1(
+                link.encode("utf-8")
+            ).hexdigest()[:10]
+            lid = f"inberlinwohnen_{raw_id}"
+            if lid in seen_ids:
+                continue
+            seen_ids.add(lid)
+            listings.append(
+                Listing(
+                    id=lid,
+                    rooms=rooms,
+                    sqm=sqm,
+                    link=link,
+                    rent=_rent_text(rent_val),
+                    title=title,
+                    address=address,
+                    provider="inBerlinWohnen",
+                )
+            )
+        except (TypeError, ValueError):
+            log.debug("inBerlin Livewire parse error", exc_info=True)
     return listings
 
 

--- a/scan.py
+++ b/scan.py
@@ -24,10 +24,12 @@ import asyncio
 import hashlib
 import html
 import logging
+import math
 import os
 import pickle
 import re
 import signal
+import unicodedata
 from datetime import datetime, timezone
 from typing import Any, Dict, List, TypedDict
 from urllib.parse import parse_qs, urljoin, urlparse
@@ -74,6 +76,35 @@ GESOBAU_URL = (
 HOWOGE_URL = "https://www.howoge.de/?type=999&tx_howrealestate_json_list%5Baction%5D=immoList"
 DEGEWO_URL = "https://www.degewo.de/immosuche"
 INBERLIN_DUPLICATE_DOMAINS = ("wbm.de", "degewo.de", "gesobau.de", "howoge.de")
+LOCATION_DISTANCE_KM = 2.0
+PREFERRED_LOCATION_TERMS = {
+    "wedding",
+    "mitte",
+    "pankow",
+    "prenzlauer berg",
+    "gesundbrunnen",
+    "moabit",
+    "weissensee",
+    "niederschonhausen",
+    "heinersdorf",
+    "wilhelmsruh",
+    "franzosisch buchholz",
+}
+PREFERRED_ZIPS = {
+    "10115", "10117", "10119", "10178", "10179",
+    "10405", "10407", "10409", "10435", "10437", "10439",
+    "10551", "10553", "10555", "10557", "10559",
+    "13086", "13088", "13089",
+    "13125", "13127", "13129", "13156", "13158", "13159", "13187", "13189",
+    "13347", "13349", "13351", "13353", "13355", "13357", "13359",
+}
+LOCATION_REFERENCE_POINTS = (
+    (52.5426, 13.3662),  # Wedding station
+    (52.5486, 13.3889),  # Gesundbrunnen / Humboldthain edge
+    (52.5200, 13.4050),  # Mitte / Alexanderplatz
+    (52.5385, 13.4244),  # Prenzlauer Berg
+    (52.5667, 13.4127),  # Pankow
+)
 
 # ───────────────────────────  LOGGING  ──────────────────────────── #
 
@@ -248,6 +279,57 @@ def _text_or_none(node: Any) -> str | None:
     text = node.get_text(" ", strip=True)
     return text or None
 
+
+def _normalize_location_text(value: Any) -> str:
+    text = unicodedata.normalize("NFKD", html.unescape(str(value or "")))
+    text = "".join(ch for ch in text if not unicodedata.combining(ch))
+    return text.casefold()
+
+
+def _contains_location_term(text: str, term: str) -> bool:
+    return re.search(rf"(?<![a-z]){re.escape(term)}(?![a-z])", text) is not None
+
+
+def _extract_zip(text: str) -> str | None:
+    match = re.search(r"\b1\d{4}\b", text)
+    return match.group(0) if match else None
+
+
+def _parse_coords(lat: Any, lng: Any) -> tuple[float, float] | None:
+    parsed_lat = _parse_number(lat)
+    parsed_lng = _parse_number(lng)
+    if parsed_lat is None or parsed_lng is None:
+        return None
+    return parsed_lat, parsed_lng
+
+
+def _distance_km(a: tuple[float, float], b: tuple[float, float]) -> float:
+    lat1, lng1 = math.radians(a[0]), math.radians(a[1])
+    lat2, lng2 = math.radians(b[0]), math.radians(b[1])
+    d_lat = lat2 - lat1
+    d_lng = lng2 - lng1
+    h = (
+        math.sin(d_lat / 2) ** 2
+        + math.cos(lat1) * math.cos(lat2) * math.sin(d_lng / 2) ** 2
+    )
+    return 6371.0 * 2 * math.asin(math.sqrt(h))
+
+
+def _location_matches(
+    texts: List[Any],
+    coords: tuple[float, float] | None = None,
+) -> bool:
+    location_text = " ".join(_normalize_location_text(text) for text in texts if text)
+    if location_text:
+        if any(_contains_location_term(location_text, term) for term in PREFERRED_LOCATION_TERMS):
+            return True
+        zip_code = _extract_zip(location_text)
+        if zip_code in PREFERRED_ZIPS:
+            return True
+    if coords is not None:
+        return min(_distance_km(coords, point) for point in LOCATION_REFERENCE_POINTS) <= LOCATION_DISTANCE_KM
+    return False
+
 # ──────────────────────────  SCANNERS  ───────────────────────────── #
 
 async def scan_gewobag() -> List[Listing]:
@@ -294,6 +376,12 @@ async def scan_gewobag() -> List[Listing]:
                     sqm = float(sqm_txt.replace("m²", "").replace(",", "."))
                     if not _passes_size_filter(rooms, sqm):
                         continue
+                    location_texts = [
+                        art.select_one("address").get_text(" ", strip=True),
+                        art.select_one("h3.angebot-title").get_text(" ", strip=True),
+                    ]
+                    if not _location_matches(location_texts):
+                        continue
                     link = art.select_one("a.read-more-link")["href"]
                     if not link.startswith("http"):
                         link = urljoin("https://www.gewobag.de", link)
@@ -325,6 +413,11 @@ async def scan_wbm() -> List[Listing]:
     listings: List[Listing] = []
     for div in soup.select("div.row.openimmo-search-list-item"):
         try:
+            area = _text_or_none(div.select_one(".area"))
+            address = _text_or_none(div.select_one(".address"))
+            title = _text_or_none(div.select_one("h2.imageTitle"))
+            if not _location_matches([area, address, title]):
+                continue
             rooms = float(div.select_one("div.main-property-rooms").text.strip().replace(",", "."))
             sqm = float(div.select_one("div.main-property-size").text
                         .replace("m²", "").replace(",", ".").strip())
@@ -341,8 +434,8 @@ async def scan_wbm() -> List[Listing]:
                     sqm=sqm,
                     link=link,
                     rent=None,
-                    title=None,
-                    address=None,
+                    title=title,
+                    address=address,
                     provider="WBM",
                 )
             )
@@ -373,6 +466,9 @@ async def scan_inberlinwohnen() -> List[Listing]:
                              .replace(".", "").replace(",", "."))
             if rooms < 3 or rent_val > MAX_RENT:
                 continue
+            title = li.find("h3").get_text(strip=True)
+            if not _location_matches([title]):
+                continue
             link = li.find("a", title=lambda t: t and "detailierte" in t)["href"]
             if not link.startswith("http"):
                 link = "https://inberlinwohnen.de" + link
@@ -385,7 +481,7 @@ async def scan_inberlinwohnen() -> List[Listing]:
                     sqm=sqm,
                     link=link,
                     rent=f"{rent_val:.0f}",
-                    title=li.find("h3").get_text(strip=True),
+                    title=title,
                     address=None,
                     provider="inBerlinWohnen",
                 )
@@ -405,6 +501,16 @@ async def scan_gesobau() -> List[Listing]:
     for item in data:
         try:
             raw = item.get("raw") or {}
+            location_texts = [
+                item.get("title"),
+                raw.get("adresse_stringS"),
+                raw.get("plz_stringS"),
+                raw.get("ort_stringS"),
+                " ".join(raw.get("region_stringM") or []),
+                " ".join(raw.get("location_stringM") or []),
+            ]
+            if not _location_matches(location_texts, _parse_coords(item.get("lat"), item.get("lng"))):
+                continue
             rooms = _parse_number(raw.get("zimmer_intS"))
             sqm = _parse_number(raw.get("wohnflaeche_floatS"))
             if not _passes_rent_filter(raw.get("warmmiete_floatS")):
@@ -511,6 +617,10 @@ def _parse_degewo_page(soup: BeautifulSoup) -> List[Listing]:
             link_node = card.select_one("h3 a[href]")
             if not link_node:
                 continue
+            title = _text_or_none(link_node)
+            address = _text_or_none(card.select_one("h3 + p"))
+            if not _location_matches([title, address]):
+                continue
             link = urljoin("https://www.degewo.de", link_node["href"])
             bookmark = card.select_one("[data-openimmo-bookmark-item-uid]")
             lid = (
@@ -525,8 +635,8 @@ def _parse_degewo_page(soup: BeautifulSoup) -> List[Listing]:
                     sqm=sqm,
                     link=link,
                     rent=_rent_text(facts.get("Warmmiete")),
-                    title=_text_or_none(link_node),
-                    address=_text_or_none(card.select_one("h3 + p")),
+                    title=title,
+                    address=address,
                     provider="degewo",
                 )
             )
@@ -570,6 +680,14 @@ async def scan_howoge() -> List[Listing]:
     listings: List[Listing] = []
     for item in data.get("immoobjects", []):
         try:
+            coords = item.get("coordinates") or {}
+            location_texts = [
+                item.get("title"),
+                item.get("district"),
+                item.get("notice"),
+            ]
+            if not _location_matches(location_texts, _parse_coords(coords.get("lat"), coords.get("lng"))):
+                continue
             rooms = _parse_number(item.get("rooms"))
             sqm = _parse_number(item.get("area"))
             if not _passes_size_filter(rooms, sqm):

--- a/scan.py
+++ b/scan.py
@@ -495,9 +495,7 @@ def _parse_inberlinwohnen_legacy(ul: Any) -> List[Listing]:
             if rooms < 3 or rent_val > MAX_RENT:
                 continue
             title = _text_or_none(li.find("h3"))
-            address = _text_or_none(li.select_one(
-                "address, .address, .tb-address, [class*='address'], [class*='Address']"
-            ))
+            address = _text_or_none(li.select_one("address, [class*='address' i]"))
             location_texts = _location_texts_or_fallback(
                 li,
                 [title, address],
@@ -543,8 +541,14 @@ def _inberlin_address_text(address: Dict[str, Any]) -> str | None:
         for part in (address.get("street"), address.get("number"))
         if part
     )
-    parts = [street_line, address.get("zipCode"), address.get("district")]
+    zip_code = str(address.get("zipCode") or "").strip()
+    city = str(address.get("city") or "Berlin").strip()
+    postal_line = " ".join(part for part in (zip_code, city) if part)
+    parts = [street_line, postal_line]
     text = ", ".join(str(part).strip() for part in parts if part)
+    district = str(address.get("district") or "").strip()
+    if text and district and district.casefold() != city.casefold():
+        text = f"{text} ({district})"
     return text or None
 
 
@@ -606,7 +610,7 @@ def _parse_inberlinwohnen_livewire(soup: BeautifulSoup) -> List[Listing]:
                     provider="inBerlinWohnen",
                 )
             )
-        except (TypeError, ValueError):
+        except Exception:
             log.debug("inBerlin Livewire parse error", exc_info=True)
     return listings
 

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -16,7 +16,7 @@ def test_scan_gewobag(monkeypatch):
     html = """
     <article id='a1' class='angebot-big-box'>
         <h3 class='angebot-title'>Top Wohnung</h3>
-        <address>Berlin</address>
+        <address>Wedding, Berlin</address>
         <table><tr class='angebot-area'><td>3 Zimmer | 65,0 m²</td></tr></table>
         <a class='read-more-link' href='/flat1'>Mehr</a>
     </article>
@@ -59,7 +59,7 @@ def test_scan_gewobag(monkeypatch):
             "link": "https://www.gewobag.de/flat1",
             "rent": None,
             "title": "Top Wohnung",
-            "address": "Berlin",
+            "address": "Wedding, Berlin",
             "provider": "Gewobag",
         }
     ]
@@ -69,7 +69,7 @@ def test_scan_gewobag_relative(monkeypatch):
     html = """
     <article id='b1' class='angebot-big-box'>
         <h3 class='angebot-title'>Noch eine</h3>
-        <address>Berlin</address>
+        <address>Pankow, Berlin</address>
         <table><tr class='angebot-area'><td>3 Zimmer | 66 m²</td></tr></table>
         <a class='read-more-link' href='../flat2'>Mehr</a>
     </article>
@@ -111,7 +111,7 @@ def test_scan_gewobag_retry_success(monkeypatch):
     html = """
     <article id='c1' class='angebot-big-box'>
         <h3 class='angebot-title'>Retry ok</h3>
-        <address>Berlin</address>
+        <address>Mitte, Berlin</address>
         <table><tr class='angebot-area'><td>3 Zimmer | 65 m²</td></tr></table>
         <a class='read-more-link' href='/flat3'>Mehr</a>
     </article>
@@ -209,6 +209,9 @@ def test_scan_gewobag_retry_fail(monkeypatch):
 def test_scan_wbm(monkeypatch):
     html = """
     <div class='row openimmo-search-list-item' data-uid='u1'>
+        <div class='area'>Pankow</div>
+        <div class='address'>Berliner Straße 1, 13189 Berlin</div>
+        <h2 class='imageTitle'>Wohnung in Pankow</h2>
         <div class='main-property-rooms'>3,0</div>
         <div class='main-property-size'>70 m²</div>
         <a title='Details' href='/d1'>Details</a>
@@ -228,8 +231,8 @@ def test_scan_wbm(monkeypatch):
             "sqm": 70.0,
             "link": "https://www.wbm.de/d1",
             "rent": None,
-            "title": None,
-            "address": None,
+            "title": "Wohnung in Pankow",
+            "address": "Berliner Straße 1, 13189 Berlin",
             "provider": "WBM",
         }
     ]
@@ -240,7 +243,7 @@ def test_scan_inberlinwohnen(monkeypatch):
     <ul id='_tb_relevant_results'>
         <li id='b1' class='tb-merkflat'>
             <a title='detailierte Ansicht' href='/b1detail'>Link</a>
-            <h3>Feine Wohnung</h3>
+            <h3>Feine Wohnung in Wedding</h3>
             <strong>3</strong>
             <strong>70</strong>
             <strong>ab 1200 €</strong>
@@ -260,7 +263,7 @@ def test_scan_inberlinwohnen(monkeypatch):
             "sqm": 70.0,
             "link": "https://inberlinwohnen.de/b1detail",
             "rent": "1200",
-            "title": "Feine Wohnung",
+            "title": "Feine Wohnung in Wedding",
             "address": None,
             "provider": "inBerlinWohnen",
         }
@@ -293,7 +296,7 @@ def test_scan_inberlinwohnen_keeps_legacy_room_filter(monkeypatch):
     <ul id='_tb_relevant_results'>
         <li id='b3' class='tb-merkflat'>
             <a title='detailierte Ansicht' href='/b3detail'>Link</a>
-            <h3>Compact three-room flat</h3>
+            <h3>Compact three-room flat in Wedding</h3>
             <strong>3</strong>
             <strong>55</strong>
             <strong>ab 1200 €</strong>
@@ -320,6 +323,13 @@ def test_parse_number_handles_german_formats():
     assert scan._passes_rent_filter("1.600,00 €")
     assert not scan._passes_rent_filter("1.600,01 €")
     assert scan._rent_text("1.179,98 €") == "1.179,98"
+
+
+def test_location_matches_preferred_text_zip_and_nearby_coords():
+    assert scan._location_matches(["Wedding"])
+    assert scan._location_matches(["Gerichtstraße 13, 13347 Berlin"])
+    assert scan._location_matches([], (52.543, 13.367))
+    assert not scan._location_matches(["Hakenfelde"], (52.5575599, 13.209115))
 
 
 def test_scan_gesobau(monkeypatch):
@@ -421,7 +431,7 @@ def test_scan_degewo(monkeypatch):
     <div class='c-teaser c-teaser--apartment'>
         <button data-openimmo-bookmark-item-uid='W-large'></button>
         <h3><a href='/immosuche/details/large'>Große Wohnung</a></h3>
-        <p>Adresse 2 | Kiez</p>
+        <p>Adresse 2 | Pankow</p>
         <div class='c-definition-list__item'><dt>1.250,50 €</dt><dd>Warmmiete</dd></div>
         <div class='c-definition-list__item'><dt>3</dt><dd>Zimmer</dd></div>
         <div class='c-definition-list__item'><dt>72,5</dt><dd>m²</dd></div>
@@ -445,7 +455,7 @@ def test_scan_degewo(monkeypatch):
             "link": "https://www.degewo.de/immosuche/details/large",
             "rent": "1.250,50",
             "title": "Große Wohnung",
-            "address": "Adresse 2 | Kiez",
+            "address": "Adresse 2 | Pankow",
             "provider": "degewo",
         }
     ]
@@ -457,7 +467,7 @@ def test_scan_howoge(monkeypatch):
             {
                 "uid": 7094,
                 "title": "Streitstraße 5, 13587 Berlin",
-                "district": "Hakenfelde",
+                "district": "Pankow",
                 "rent": 803,
                 "area": 73,
                 "rooms": 3,

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -353,10 +353,54 @@ def test_scan_inberlinwohnen_livewire(monkeypatch):
             "link": "https://inberlinwohnen.example/listing/live-1",
             "rent": "1.200",
             "title": "Große Wohnung am Nordufer",
-            "address": "Nordufer 12, 13353, Wedding",
+            "address": "Nordufer 12, 13353 Berlin (Wedding)",
             "provider": "inBerlinWohnen",
         }
     ]
+
+
+def test_scan_inberlinwohnen_skips_malformed_livewire_snapshot(monkeypatch):
+    bad_snapshot = json.dumps([])
+    good_snapshot = json.dumps(
+        {
+            "data": {
+                "item": [
+                    {
+                        "id": "live-1",
+                        "title": "Große Wohnung am Nordufer",
+                        "deeplink": "https://inberlinwohnen.example/listing/live-1",
+                        "rooms": "3",
+                        "area": "72,5",
+                        "rentGross": "1.200,00",
+                        "address": [
+                            {
+                                "street": "Nordufer",
+                                "number": "12",
+                                "zipCode": "13353",
+                                "district": "Wedding",
+                                "lat": "52.5443",
+                                "lon": "13.3569",
+                            },
+                            {"s": "arr"},
+                        ],
+                    },
+                    {"s": "arr"},
+                ]
+            }
+        }
+    )
+    html = f"""
+    <div wire:snapshot='{bad_snapshot}'></div>
+    <div wire:snapshot='{good_snapshot}'></div>
+    """
+
+    async def fake_fetch(url, *, params=None, timeout=12):
+        return html
+
+    monkeypatch.setattr(scan, "fetch", fake_fetch)
+    listings = asyncio.run(scan.scan_inberlinwohnen())
+    assert len(listings) == 1
+    assert listings[0]["id"] == "inberlinwohnen_live-1"
 
 
 def test_scan_inberlinwohnen_filters_non_preferred_livewire(monkeypatch):

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import asyncio
+import json
 
 # Ensure project root is on path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -238,12 +239,50 @@ def test_scan_wbm(monkeypatch):
     ]
 
 
+def test_scan_wbm_filters_non_preferred_location(monkeypatch):
+    html = """
+    <div class='row openimmo-search-list-item' data-uid='u2'>
+        <div class='area'>Spandau</div>
+        <div class='address'>Streitstraße 5, 13587 Berlin</div>
+        <h2 class='imageTitle'>Wohnung in Hakenfelde</h2>
+        <div class='main-property-rooms'>3,0</div>
+        <div class='main-property-size'>70 m²</div>
+        <a title='Details' href='/d2'>Details</a>
+    </div>
+    """
+
+    async def fake_fetch(url, *, params=None, timeout=12):
+        return html
+
+    monkeypatch.setattr(scan, "fetch", fake_fetch)
+    assert asyncio.run(scan.scan_wbm()) == []
+
+
+def test_scan_wbm_location_fallback(monkeypatch):
+    html = """
+    <div class='row openimmo-search-list-item' data-uid='u3'>
+        Wedding 13347 Berlin
+        <div class='main-property-rooms'>3,0</div>
+        <div class='main-property-size'>70 m²</div>
+        <a title='Details' href='/d3'>Details</a>
+    </div>
+    """
+
+    async def fake_fetch(url, *, params=None, timeout=12):
+        return html
+
+    monkeypatch.setattr(scan, "fetch", fake_fetch)
+    listings = asyncio.run(scan.scan_wbm())
+    assert listings and listings[0]["link"] == "https://www.wbm.de/d3"
+
+
 def test_scan_inberlinwohnen(monkeypatch):
     html = """
     <ul id='_tb_relevant_results'>
         <li id='b1' class='tb-merkflat'>
             <a title='detailierte Ansicht' href='/b1detail'>Link</a>
             <h3>Feine Wohnung in Wedding</h3>
+            <address>Gerichtstraße 13, 13347 Berlin</address>
             <strong>3</strong>
             <strong>70</strong>
             <strong>ab 1200 €</strong>
@@ -264,10 +303,98 @@ def test_scan_inberlinwohnen(monkeypatch):
             "link": "https://inberlinwohnen.de/b1detail",
             "rent": "1200",
             "title": "Feine Wohnung in Wedding",
-            "address": None,
+            "address": "Gerichtstraße 13, 13347 Berlin",
             "provider": "inBerlinWohnen",
         }
     ]
+
+
+def test_scan_inberlinwohnen_livewire(monkeypatch):
+    snapshot = json.dumps(
+        {
+            "data": {
+                "item": [
+                    {
+                        "id": "live-1",
+                        "title": "Große Wohnung am Nordufer",
+                        "deeplink": "https://inberlinwohnen.example/listing/live-1",
+                        "rooms": "3",
+                        "area": "72,5",
+                        "rentGross": "1.200,00",
+                        "address": [
+                            {
+                                "street": "Nordufer",
+                                "number": "12",
+                                "zipCode": "13353",
+                                "district": "Wedding",
+                                "lat": "52.5443",
+                                "lon": "13.3569",
+                            },
+                            {"s": "arr"},
+                        ],
+                    },
+                    {"s": "arr"},
+                ]
+            }
+        }
+    )
+    html = f"<div wire:snapshot='{snapshot}'></div>"
+
+    async def fake_fetch(url, *, params=None, timeout=12):
+        return html
+
+    monkeypatch.setattr(scan, "fetch", fake_fetch)
+    listings = asyncio.run(scan.scan_inberlinwohnen())
+    assert listings == [
+        {
+            "id": "inberlinwohnen_live-1",
+            "rooms": 3.0,
+            "sqm": 72.5,
+            "link": "https://inberlinwohnen.example/listing/live-1",
+            "rent": "1.200",
+            "title": "Große Wohnung am Nordufer",
+            "address": "Nordufer 12, 13353, Wedding",
+            "provider": "inBerlinWohnen",
+        }
+    ]
+
+
+def test_scan_inberlinwohnen_filters_non_preferred_livewire(monkeypatch):
+    snapshot = json.dumps(
+        {
+            "data": {
+                "item": [
+                    {
+                        "id": "live-2",
+                        "title": "Wohnung in Buckow",
+                        "deeplink": "https://inberlinwohnen.example/listing/live-2",
+                        "rooms": "3",
+                        "area": "72",
+                        "rentGross": "1.200,00",
+                        "address": [
+                            {
+                                "street": "In den Bauerngärten",
+                                "number": "10",
+                                "zipCode": "12349",
+                                "district": "Neukölln",
+                                "lat": "52.41437138",
+                                "lon": "13.43496921",
+                            },
+                            {"s": "arr"},
+                        ],
+                    },
+                    {"s": "arr"},
+                ]
+            }
+        }
+    )
+    html = f"<div wire:snapshot='{snapshot}'></div>"
+
+    async def fake_fetch(url, *, params=None, timeout=12):
+        return html
+
+    monkeypatch.setattr(scan, "fetch", fake_fetch)
+    assert asyncio.run(scan.scan_inberlinwohnen()) == []
 
 
 def test_scan_inberlinwohnen_skip_wbm(monkeypatch):
@@ -275,7 +402,7 @@ def test_scan_inberlinwohnen_skip_wbm(monkeypatch):
     <ul id='_tb_relevant_results'>
         <li id='b2' class='tb-merkflat'>
             <a title='detailierte Ansicht' href='https://www.wbm.de/foo'>Link</a>
-            <h3>WBM</h3>
+            <h3>WBM listing in Wedding</h3>
             <strong>3</strong>
             <strong>70</strong>
             <strong>ab 1200 €</strong>


### PR DESCRIPTION
## Summary
- Adds a preferred-location filter centered on Wedding, Mitte, and Pankow.
- Allows nearby/borderline matches via accepted adjacent neighborhoods, preferred ZIP codes, and coordinates within 2 km of reference points for Wedding, Gesundbrunnen, Mitte, Prenzlauer Berg, and Pankow.
- Applies the filter across the active scanners using each provider's available location data: structured district/coordinates where available, otherwise card title/address/neighborhood text.

## Review follow-up
- Gewobag location selectors now use safe text extraction instead of raising on missing address/title nodes.
- WBM now parses rooms/sqm before the location filter and falls back to full card text with a warning if location selectors disappear.
- inBerlinWohnen now uses address text on the legacy markup and parses the current Livewire listing snapshots for address, ZIP, district, and coordinates.
- inBerlinWohnen Livewire parsing now skips malformed snapshot envelopes without aborting the scan loop.
- inBerlinWohnen address text now formats as `Street 12, 13353 Berlin (District)`.
- ZIP matching is narrowed to Berlin postal-code range candidates before checking the preferred ZIP allowlist.

## Notes
- This does not perform live public-transport route planning. I kept it deterministic and cheap for the 2-minute cron path; adding transit routing would need a reliable VBB/BVG API integration and caching.
- No WBS exclusion changes are included.

## Validation
- `/tmp/berlinhome-venv/bin/pytest -q` -> 24 passed.
- `/tmp/berlinhome-venv/bin/python -m py_compile scan.py`
- `git diff --check`
- Live no-notification scanner check on 2026-05-21: WBM/inBerlinWohnen/GESOBAU/degewo/HOWOGE all returned 0 preferred matches. A targeted inBerlinWohnen inspection saw 10 Livewire listing snapshots, with the visible examples filtered because they were outside the preferred areas or below size/room constraints.
